### PR TITLE
chore: bump ruff pre-commit hook to v0.14.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.14.6
     hooks:
       - id: ruff
         name: "Run ruff linter and apply fixes"


### PR DESCRIPTION
## Summary
- Bump `ruff-pre-commit` from v0.2.0 to v0.14.6 for consistent tab indentation enforcement

## Test plan
- [ ] Verify `pre-commit install && pre-commit run --all-files` passes
- [ ] Confirm ruff format still uses tab indentation

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)